### PR TITLE
.wider matches on same element as on .grid

### DIFF
--- a/gridism.css
+++ b/gridism.css
@@ -116,7 +116,8 @@
 
 /* Expand the wrap a bit further on larger screens */
 @media screen and (min-width: 1180px) {
-  .wider .grid {
+  .wider .grid,
+  .grid.wider {
     max-width: 1180px;
     margin: 0 auto;
   }


### PR DESCRIPTION
This makes .wider consistent with .wrap (.wrap is allowed on the .grid, or as its parent).
