### PR TITLE
Make gridism.css "mobile first" compliant

### DIFF
--- a/gridism.css
+++ b/gridism.css
@@ -23,16 +23,6 @@
   padding: 10px;
 }
 
-/* This ensures the outer gutters are equal to the (doubled) inner gutters. */
-.grid .unit:first-child { padding-left: 20px; }
-.grid .unit:last-child { padding-right: 20px; }
-
-/* Nested grids already have padding though, so let’s nuke it */
-.unit .unit:first-child { padding-left: 0; }
-.unit .unit:last-child { padding-right: 0; }
-.unit .grid:first-child > .unit { padding-top: 0; }
-.unit .grid:last-child > .unit { padding-bottom: 0; }
-
 /* Let people nuke the gutters/padding completely in a couple of ways */
 .no-gutters .unit,
 .unit.no-gutters {
@@ -45,24 +35,6 @@
   max-width: 978px;
   margin: 0 auto;
 }
-
-/* Width classes also have shorthand versions numbered as fractions
- * For example: for a grid unit 1/3 (one third) of the parent width,
- * simply apply class="w-1-3" to the element. */
-.grid .whole,          .grid .w-1-1 { width: 100%; }
-.grid .half,           .grid .w-1-2 { width: 50%; }
-.grid .one-third,      .grid .w-1-3 { width: 33.3332%; }
-.grid .two-thirds,     .grid .w-2-3 { width: 66.6665%; }
-.grid .one-quarter,
-.grid .one-fourth,     .grid .w-1-4 { width: 25%; }
-.grid .three-quarters,
-.grid .three-fourths,  .grid .w-3-4 { width: 75%; }
-.grid .one-fifth,      .grid .w-1-5 { width: 20%; }
-.grid .two-fifths,     .grid .w-2-5 { width: 40%; }
-.grid .three-fifths,   .grid .w-3-5 { width: 60%; }
-.grid .four-fifths,    .grid .w-4-5 { width: 80%; }
-.grid .golden-small,   .grid .w-g-s { width: 38.2716%; } /* Golden section: smaller piece */
-.grid .golden-large,   .grid .w-g-l { width: 61.7283%; } /* Golden section: larger piece */
 
 /* Clearfix after every .grid */
 .grid {
@@ -91,12 +63,10 @@
   max-width: 100%;
 }
 
-/* Responsive Stuff */
-@media screen and (max-width: 568px) {
   /* Stack anything that isn’t full-width on smaller screens 
      and doesn't provide the no-stacking-on-mobiles class */
   .grid:not(.no-stacking-on-mobiles) > .unit {
-    width: 100% !important;
+    width: 100%;
     padding-left: 20px;
     padding-right: 20px;
   }
@@ -112,6 +82,45 @@
   .hide-on-mobiles {
     display: none !important;
   }
+
+/* Responsive Stuff */
+@media screen and (min-width: 569px) {
+/* This ensures the outer gutters are equal to the (doubled) inner gutters. */
+.grid .unit:first-child { padding-left: 20px; }
+.grid .unit:last-child { padding-right: 20px; }
+
+/* Nested grids already have padding though, so let’s nuke it */
+.unit .unit:first-child { padding-left: 0; }
+.unit .unit:last-child { padding-right: 0; }
+.unit .grid:first-child > .unit { padding-top: 0; }
+.unit .grid:last-child > .unit { padding-bottom: 0; }
+
+/* Width classes also have shorthand versions numbered as fractions
+ * For example: for a grid unit 1/3 (one third) of the parent width,
+ * simply apply class="w-1-3" to the element. */
+.grid .unit.whole,          .grid .unit.w-1-1 { width: 100%; }
+.grid .unit.half,           .grid .unit.w-1-2 { width: 50%; }
+.grid .unit.one-third,      .grid .unit.w-1-3 { width: 33.3332%; }
+.grid .unit.two-thirds,     .grid .unit.w-2-3 { width: 66.6665%; }
+.grid .unit.one-quarter,
+.grid .unit.one-fourth,     .grid .unit.w-1-4 { width: 25%; }
+.grid .unit.three-quarters,
+.grid .unit.three-fourths,  .grid .unit.w-3-4 { width: 75%; }
+.grid .unit.one-fifth,      .grid .unit.w-1-5 { width: 20%; }
+.grid .unit.two-fifths,     .grid .unit.w-2-5 { width: 40%; }
+.grid .unit.three-fifths,   .grid .unit.w-3-5 { width: 60%; }
+.grid .unit.four-fifths,    .grid .unit.w-4-5 { width: 80%; }
+.grid .unit.golden-small,   .grid .unit.w-g-s { width: 38.2716%; } /* Golden section: smaller piece */
+.grid .unit.golden-large,   .grid .unit.w-g-l { width: 61.7283%; } /* Golden section: larger piece */
+
+/* Change the behaviour set above */
+.center-on-mobiles {
+  text-align: inherit !important;
+}
+/* Is there a better way to bring back the display */
+.hide-on-mobiles {
+  display: inline  !important;
+}
 }
 
 /* Expand the wrap a bit further on larger screens */


### PR DESCRIPTION
This is my attempt to make gridism "mobile first". I am not a web expert and quite probably I haven't done what I mean right. Although, one very simple page I have designed recently behaves as expected without any modifications.

I didn't "fix" indentation to make the patch more readable.
