### PR TITLE
Make padding less specific for easier override

### DIFF
--- a/gridism.css
+++ b/gridism.css
@@ -20,6 +20,8 @@
 .grid .unit {
   float: left;
   width: 100%;
+}
+.unit {
   padding: 10px;
 }
 


### PR DESCRIPTION
When pairing `.unit` with another class, it seems strange to need to walk in through `.grid` in order to override padding.
